### PR TITLE
Removed Moq as a dependency

### DIFF
--- a/buildpackage/MvcRouteTester.nuspec.template
+++ b/buildpackage/MvcRouteTester.nuspec.template
@@ -13,7 +13,6 @@
     <copyright>Copyright 2013</copyright>
     <tags>ASP MVC Route Test NUnit UnitTest API ApiController</tags>
     <dependencies>
-      <dependency id="Moq" version="4.0.10827" />
       <dependency id="NUnit" version="2.6.2" />
     </dependencies>
   </metadata>

--- a/src/MvcRouteTester/Mockery.cs
+++ b/src/MvcRouteTester/Mockery.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Specialized;
+﻿using System.Collections.Specialized;
 using System.Web;
-using Moq;
 
 namespace MvcRouteTester
 {
@@ -13,12 +11,58 @@ namespace MvcRouteTester
 			var relativeUrl = routeParts[0];
 			var queryParams = UrlHelpers.MakeQueryParams(url);
 
-			var httpContextMock = new Mock<HttpContextBase>();
-			httpContextMock.Setup(c => c.Request.AppRelativeCurrentExecutionFilePath).Returns(relativeUrl);
-			httpContextMock.Setup(c => c.Request.QueryString).Returns(queryParams);
-			httpContextMock.Setup(c => c.Request.Params).Returns(queryParams);
-			httpContextMock.Setup(c => c.Request.PathInfo).Returns(string.Empty);
-			return httpContextMock.Object;
+			return new PrivateHttpContext(new PrivateHttpRequest(relativeUrl, queryParams));
+		}
+
+		class PrivateHttpContext : HttpContextBase
+		{
+			readonly HttpRequestBase request;
+
+			public PrivateHttpContext(HttpRequestBase request)
+			{
+				this.request = request;
+			}
+
+			public override HttpRequestBase Request {
+				get {
+					return this.request;
+				}
+			}
+		}
+
+		class PrivateHttpRequest : HttpRequestBase
+		{
+			readonly string relativeUrl;
+			readonly NameValueCollection queryParams;
+
+			public PrivateHttpRequest(string relativeUrl, NameValueCollection queryParams)
+			{
+				this.relativeUrl = relativeUrl;
+				this.queryParams = queryParams;
+			}
+
+			public override string AppRelativeCurrentExecutionFilePath {
+				get {
+					return this.relativeUrl;
+				}
+			}
+			public override NameValueCollection QueryString {
+				get {
+					return this.queryParams;
+				}
+			}
+
+			public override NameValueCollection Params {
+				get {
+					return this.queryParams;
+				}
+			}
+
+			public override string PathInfo {
+				get {
+					return string.Empty;
+				}
+			}
 		}
 	}
 }

--- a/src/MvcRouteTester/MvcRouteTester.csproj
+++ b/src/MvcRouteTester/MvcRouteTester.csproj
@@ -33,9 +33,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Moq">
-      <HintPath>..\..\packages\Moq.4.0.10827\lib\NET40\Moq.dll</HintPath>
-    </Reference>
     <Reference Include="nunit.framework, Version=2.6.2.12296, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>
     </Reference>

--- a/src/MvcRouteTester/packages.config
+++ b/src/MvcRouteTester/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Moq" version="4.0.10827" targetFramework="net45" />
   <package id="NUnit" version="2.6.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Removed Moq as a dependency from the MvcRouteTester c# project and its
package.config, and from the nuspec template.
Replaced Moq usage by two dedicated classes that do what Moq used to do.
