### PR TITLE
Remove nunit dependency

### DIFF
--- a/src/MvcRouteTester.Test/ApiRoute/FluentExtensionsTests.cs
+++ b/src/MvcRouteTester.Test/ApiRoute/FluentExtensionsTests.cs
@@ -27,7 +27,7 @@ namespace MvcRouteTester.Test.ApiRoute
 		[TearDown]
 		public void TearDown()
 		{
-			RouteAssert.UseAssertEngine(new NunitAssertEngine());
+			RouteAssert.UseAssertEngine(new AssertEngine());
 		}
 
 		[Test]

--- a/src/MvcRouteTester.Test/ApiRoute/FromBodyTests.cs
+++ b/src/MvcRouteTester.Test/ApiRoute/FromBodyTests.cs
@@ -27,7 +27,7 @@ namespace MvcRouteTester.Test.ApiRoute
 		[TearDown]
 		public void TearDown()
 		{
-			RouteAssert.UseAssertEngine(new NunitAssertEngine());
+			RouteAssert.UseAssertEngine(new AssertEngine());
 		}
 
 		[Test]

--- a/src/MvcRouteTester.Test/ApiRoute/RouteExpectionTests.cs
+++ b/src/MvcRouteTester.Test/ApiRoute/RouteExpectionTests.cs
@@ -27,7 +27,7 @@ namespace MvcRouteTester.Test.ApiRoute
 		[TearDown]
 		public void TearDown()
 		{
-			RouteAssert.UseAssertEngine(new NunitAssertEngine());
+			RouteAssert.UseAssertEngine(new AssertEngine());
 		}
 
 		[Test]

--- a/src/MvcRouteTester.Test/ApiRoute/RouteMethodTests.cs
+++ b/src/MvcRouteTester.Test/ApiRoute/RouteMethodTests.cs
@@ -26,7 +26,7 @@ namespace MvcRouteTester.Test.ApiRoute
 		[TearDown]
 		public void TearDown()
 		{
-			RouteAssert.UseAssertEngine(new NunitAssertEngine());
+			RouteAssert.UseAssertEngine(new AssertEngine());
 		}
 
 		[Test]

--- a/src/MvcRouteTester.Test/WebRoute/FluentExtensionsTests.cs
+++ b/src/MvcRouteTester.Test/WebRoute/FluentExtensionsTests.cs
@@ -27,7 +27,7 @@ namespace MvcRouteTester.Test.WebRoute
 		[TearDown]
 		public void TearDown()
 		{
-			RouteAssert.UseAssertEngine(new NunitAssertEngine());
+			RouteAssert.UseAssertEngine(new AssertEngine());
 		}
 
 		[Test]

--- a/src/MvcRouteTester.Test/WebRoute/FromBodyTests.cs
+++ b/src/MvcRouteTester.Test/WebRoute/FromBodyTests.cs
@@ -27,7 +27,7 @@ namespace MvcRouteTester.Test.WebRoute
 		[TearDown]
 		public void TearDown()
 		{
-			RouteAssert.UseAssertEngine(new NunitAssertEngine());
+			RouteAssert.UseAssertEngine(new AssertEngine());
 		}
 
 		[Test]

--- a/src/MvcRouteTester.Test/WebRoute/HasRouteTests.cs
+++ b/src/MvcRouteTester.Test/WebRoute/HasRouteTests.cs
@@ -25,7 +25,7 @@ namespace MvcRouteTester.Test.WebRoute
 		[TearDown]
 		public void TearDown()
 		{
-			RouteAssert.UseAssertEngine(new NunitAssertEngine());
+			RouteAssert.UseAssertEngine(new AssertEngine());
 		}
 
 		[Test]

--- a/src/MvcRouteTester/Assertions/AssertEngine.cs
+++ b/src/MvcRouteTester/Assertions/AssertEngine.cs
@@ -1,12 +1,12 @@
-﻿using NUnit.Framework;
+﻿using System;
 
 namespace MvcRouteTester.Assertions
 {
-	public class NunitAssertEngine : IAssertEngine
+	public class AssertEngine : IAssertEngine
 	{
 		public void Fail(string message)
 		{
-			Assert.Fail(message);
+			throw new AssertionException(message);
 		}
 		
 		/// <summary>
@@ -23,7 +23,11 @@ namespace MvcRouteTester.Assertions
 				return;
 			}
 
-			StringAssert.AreEqualIgnoringCase(s1, s2, message);
+			if (string.Equals(s1, s2, StringComparison.InvariantCultureIgnoreCase)) 
+				return;
+
+			var exceptionMessage = string.Format("{0}\n Strings do not match: \n Expected:{1}\nActual{2}", message, s1, s2);
+			throw new AssertionException(exceptionMessage);
 		}
 	}
 }

--- a/src/MvcRouteTester/Assertions/AssertionException.cs
+++ b/src/MvcRouteTester/Assertions/AssertionException.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace MvcRouteTester.Assertions
+{
+    [Serializable]
+    public class AssertionException : Exception
+    {
+        internal AssertionException(string message)
+            : base(message)
+        {
+        }
+
+        protected AssertionException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/src/MvcRouteTester/Assertions/Asserts.cs
+++ b/src/MvcRouteTester/Assertions/Asserts.cs
@@ -4,7 +4,7 @@
 	{
 		static Asserts()
 		{
-			AssertEngine = new NunitAssertEngine();
+			AssertEngine = new AssertEngine();
 		}
 
 		internal static IAssertEngine AssertEngine { get; set; }

--- a/src/MvcRouteTester/MvcRouteTester.csproj
+++ b/src/MvcRouteTester/MvcRouteTester.csproj
@@ -33,9 +33,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=2.6.2.12296, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
@@ -48,9 +45,10 @@
     <Compile Include="ApiRoute\ApiRouteAssert.cs" />
     <Compile Include="ApiRoute\BodyReader.cs" />
     <Compile Include="ApiRoute\Generator.cs" />
+    <Compile Include="Assertions\AssertionException.cs" />
     <Compile Include="Assertions\Asserts.cs" />
     <Compile Include="Assertions\IAssertEngine.cs" />
-    <Compile Include="Assertions\NunitAssertEngine.cs" />
+    <Compile Include="Assertions\AssertEngine.cs" />
     <Compile Include="FluentApiExtensions.cs" />
     <Compile Include="Fluent\ExpressionReader.cs" />
     <Compile Include="FluentExtensions.cs" />
@@ -67,9 +65,6 @@
     <Compile Include="Common\UrlHelpers.cs" />
     <Compile Include="WebRoute\WebRouteAssert.cs" />
     <Compile Include="WebRoute\Reader.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/MvcRouteTester/packages.config
+++ b/src/MvcRouteTester/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="NUnit" version="2.6.2" targetFramework="net45" />
-</packages>


### PR DESCRIPTION
Instead of using nunit methods to cause a failure the AssertEngine throws a a custom exception that the unit test frameworks will register as a failure. We do however lose the extra information that nunit provides when comparing strings.

I tested this with the NUnit, xUnit and MSTest frameworks and all three returned the same results when given the same test methods.
