### PR TITLE
Add the ability to set a custom HttpControllerSelector

### DIFF
--- a/src/MvcRouteTester/ApiRoute/ApiRouteAssert.cs
+++ b/src/MvcRouteTester/ApiRoute/ApiRouteAssert.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Web.Http;
+using System.Web.Http.Dispatcher;
 using MvcRouteTester.Assertions;
 using MvcRouteTester.Common;
 
@@ -9,6 +10,13 @@ namespace MvcRouteTester.ApiRoute
 {
 	internal static class ApiRouteAssert
 	{
+		static ApiRouteAssert()
+		{
+			ControllerSelectorType = typeof (DefaultHttpControllerSelector);
+		}
+
+		internal static Type ControllerSelectorType;
+
 		internal static void HasRoute(HttpConfiguration config, string url, HttpMethod httpMethod)
 		{
 			var absoluteUrl = UrlHelpers.MakeAbsolute(url);

--- a/src/MvcRouteTester/ApiRoute/Generator.cs
+++ b/src/MvcRouteTester/ApiRoute/Generator.cs
@@ -267,7 +267,7 @@ namespace MvcRouteTester.ApiRoute
 			if (matchedRoute != null)
 			{
 				request.Properties[HttpPropertyKeys.HttpRouteDataKey] = matchedRoute;
-				controllerSelector = new DefaultHttpControllerSelector(config);
+				controllerSelector = (IHttpControllerSelector) Activator.CreateInstance(ApiRouteAssert.ControllerSelectorType, config);
 				controllerContext = new HttpControllerContext(config, matchedRoute, request);
 			}
 		}

--- a/src/MvcRouteTester/RouteAssert.cs
+++ b/src/MvcRouteTester/RouteAssert.cs
@@ -185,5 +185,13 @@ namespace MvcRouteTester
 		{
 			Asserts.AssertEngine = engine;
 		}
+
+		/// <summary>
+		/// Sets the type of selector to be used to locate the controller for api routes
+		/// </summary>
+		public static void UseHttpControllerSelector(Type selector)
+		{
+			ApiRouteAssert.ControllerSelectorType = selector;
+		}
 	}
 }


### PR DESCRIPTION
In one of my projects I need to use a custom HttpControllerSelector to avoid name collisions between api controllers.This change enables users to set the selector if they are using a custom one.

To use, call the following before doing any asserts:
`RouteAssert.UseHttpControllerSelector(typeof(MyCustomHttpControllerSelector));`

If you dont set it, it will use the standard DefaultHttpControllerSelector.
