### PR TITLE
MockHttpContext does not stub methods correctly

### DIFF
--- a/src/MvcRouteTester.Test/HttpMocking/HttpMockeryTest.cs
+++ b/src/MvcRouteTester.Test/HttpMocking/HttpMockeryTest.cs
@@ -87,5 +87,14 @@ namespace MvcRouteTester.Test.HttpMocking
 
 			Assert.That(context.Request.PathInfo, Is.EqualTo(string.Empty));
 		}
+
+        [Test]
+        public void ShouldHaveStubbedContextCorrectly()
+        {
+            var context = HttpMockery.ContextForUrl("");
+            context.RewritePath("");
+            context.RewritePath("", "", "");
+        }
+        
 	}
 }

--- a/src/MvcRouteTester/HttpMocking/HttpMockery.cs
+++ b/src/MvcRouteTester/HttpMocking/HttpMockery.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
 using System.Web;
 using System.Web.Routing;
 using MvcRouteTester.Common;
@@ -7,7 +8,7 @@ namespace MvcRouteTester.HttpMocking
 {
 	public class HttpMockery
 	{
-		public static HttpContextBase ContextForUrl(string url)
+        public static HttpContextBase ContextForUrl(string url)
 		{
 			return ContextForUrl(HttpMethod.Get, url, string.Empty);
 		}

--- a/src/MvcRouteTester/HttpMocking/MockHttpContext.cs
+++ b/src/MvcRouteTester/HttpMocking/MockHttpContext.cs
@@ -23,5 +23,16 @@ namespace MvcRouteTester.HttpMocking
 		{
 			get { return items; }
 		}
+
+        public override void RewritePath(string filePath, string pathInfo, string queryString)
+        {
+            
+        }
+
+        public override void RewritePath(string path)
+        {
+            
+        }
+        
 	}
 }

--- a/src/MvcRouteTester/HttpMocking/MockHttpRequest.cs
+++ b/src/MvcRouteTester/HttpMocking/MockHttpRequest.cs
@@ -72,5 +72,6 @@ namespace MvcRouteTester.HttpMocking
 		{
 			requestContext = context;
 		}
-	}
+
+      }
 }


### PR DESCRIPTION
I am trying to test a custom route that calls the ReWritePath method on the HttpContext which throws a not implemented exception. 

I have added a test to reproduce the problem.

It would be great if you could include this.
