### PR TITLE
Take ActionName attributes into account in ExpressionReader

### DIFF
--- a/src/MvcRouteTester.Test/Fluent/ExpressionReaderTests.cs
+++ b/src/MvcRouteTester.Test/Fluent/ExpressionReaderTests.cs
@@ -16,6 +16,12 @@ namespace MvcRouteTester.Test.Fluent
 			return new EmptyResult();
 		}
 
+		[ActionName("ActionNameAttribute")]
+		public ActionResult MethodName()
+		{
+			return new EmptyResult();
+		}
+
 		public ActionResult GetItem(int id = 12)
 		{
 			return new EmptyResult();
@@ -73,6 +79,18 @@ namespace MvcRouteTester.Test.Fluent
 
 			Assert.That(result.Controller, Is.EqualTo("Test"));
 			Assert.That(result.Action, Is.EqualTo("Index"));
+		}
+
+		[Test]
+		public void ReadGetsActionFromAttributeWhenPresent()
+		{
+			var reader = new ExpressionReader();
+
+			Expression<Func<TestController, ActionResult>> args = c => c.MethodName();
+			var result = reader.Read(args);
+
+			Assert.That(result.Controller, Is.EqualTo("Test"));
+			Assert.That(result.Action, Is.EqualTo("ActionNameAttribute"));
 		}
 
 		[Test]

--- a/src/MvcRouteTester/Fluent/ExpressionReader.cs
+++ b/src/MvcRouteTester/Fluent/ExpressionReader.cs
@@ -118,7 +118,20 @@ namespace MvcRouteTester.Fluent
 
 		private string ActionName(MethodCallExpression methodCall)
 		{
-			return  methodCall.Method.Name;
+			// Look for System.Web.Mvc ActionName attribute
+			var attributes = methodCall.Method.GetCustomAttributes(typeof(System.Web.Mvc.ActionNameAttribute), true);
+
+			if (attributes.Length > 0)
+				return ((System.Web.Mvc.ActionNameAttribute)attributes[0]).Name;
+
+			// Look for System.Web.Http ActionName attribute
+			attributes = methodCall.Method.GetCustomAttributes(typeof(System.Web.Http.ActionNameAttribute), true);
+
+			if (attributes.Length > 0)
+				return ((System.Web.Http.ActionNameAttribute)attributes[0]).Name;
+
+			// Otherwise, just use the method name
+			return methodCall.Method.Name;
 		}
 
 		private IList<RouteValue> ReadParameters(MethodCallExpression methodCall)


### PR DESCRIPTION
@AnthonySteele thank you for putting this project together!

I've run into an issue where [ActionName] is not taken into account.

Given a controller method like this (code is approximate):

``` C#
[HttpPut]
[ActionName("Items")]
public void PutItem(string id)
{
}
```

This assertion will fail b/c it asserts the action name to be "PutItem" even though request is routed properly if requested through IIS.

``` C#
config
    .ShouldMap("/my/items")
    .To<UserController>(HttpMethod.Put, c => c.PutItem(""));
```

This small change to the ExpressionReader seems to fix the issue.

I've added another test as well to demonstrate the issue and fix.
