### PR TITLE
Idea for fixing Issue #37.

### DIFF
--- a/src/MvcRouteTester/DirectRouteExtensions.cs
+++ b/src/MvcRouteTester/DirectRouteExtensions.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Web.Routing;
+
+namespace MvcRouteTester.WebRoute
+{
+	public static class DirectRouteExtensions
+	{
+		public static bool HasDirectRouteMatch(this RouteData routeData)
+		{
+			if (routeData == null)
+			{
+				//throw Error.ArgumentNull("routeData");
+				throw new NotImplementedException();
+			}
+
+			return routeData.Values.ContainsKey(RouteDataTokenKeys.DirectRouteMatches);
+		}
+
+		public static IEnumerable<RouteData> GetDirectRouteMatches(this RouteData routeData)
+		{
+			return GetRouteDataValue<IEnumerable<RouteData>>(routeData, RouteDataTokenKeys.DirectRouteMatches) ?? Enumerable.Empty<RouteData>();
+		}
+
+		private static T GetRouteDataValue<T>(this RouteData routeData, string key)
+		{
+			if (routeData == null)
+			{
+				//throw Error.ArgumentNull("routeData");
+				throw new NotImplementedException();
+			}
+
+			if (key == null)
+			{
+				//throw Error.ArgumentNull("key");
+				throw new NotImplementedException();
+			}
+
+			object value;
+			if (routeData.Values.TryGetValue(key, out value))
+			{
+				return (T)value;
+			}
+			else
+			{
+				return default(T);
+			}
+		}
+	}
+
+	public class RouteDataTokenKeys
+	{
+		public const string DirectRouteMatches = "MS_DirectRouteMatches";
+	}
+}

--- a/src/MvcRouteTester/MvcRouteTester.csproj
+++ b/src/MvcRouteTester/MvcRouteTester.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Common\RouteValueExtensions.cs" />
     <Compile Include="Common\RouteValueOrigin.cs" />
     <Compile Include="Common\RouteValues.cs" />
+    <Compile Include="DirectRouteExtensions.cs" />
     <Compile Include="FluentApiExtensions.cs" />
     <Compile Include="Fluent\ExpressionReader.cs" />
     <Compile Include="FluentExtensions.cs" />

--- a/src/MvcRouteTester/WebRoute/WebRouteAssert.cs
+++ b/src/MvcRouteTester/WebRoute/WebRouteAssert.cs
@@ -38,10 +38,48 @@ namespace MvcRouteTester.WebRoute
 				Asserts.Fail(message);
 			}
 
-			var webRouteReader = new Reader();
-			var actualProps = webRouteReader.GetRequestProperties(routeData, httpContext.Request, bodyFormat);
-			var verifier = new Verifier(expectedProps, actualProps, url);
-			verifier.VerifyExpectations();
+			var hasDirectRouteMatch = routeData.HasDirectRouteMatch();
+			if (hasDirectRouteMatch)
+			{
+				var webRouteReader = new Reader();
+
+				//***********************
+				// Option 1
+				// - Somehow individually verify each routeData. If one comes back with no failures, then we are good to go
+				//***********************
+				foreach (var rd in routeData.GetDirectRouteMatches())
+				{
+					// Somehow individually very each routeData. If one comes back with no failures, then we are good to go
+
+					var actualProps = webRouteReader.GetRequestProperties(rd, httpContext.Request, bodyFormat);
+					var verifier = new Verifier(expectedProps, actualProps, url);
+					// how would this work???
+					verifier.VerifyExpectations();
+				}
+				//***********************
+
+				//***********************
+				// Option 2
+				// - Somehow verify all routeData's via the Verifier. If one comes back with no failures, then we are good to go
+				//***********************
+				var actualPropsList = new List<RouteValues>();
+				foreach (var rd in routeData.GetDirectRouteMatches())
+				{
+					actualPropsList.Add(webRouteReader.GetRequestProperties(rd, httpContext.Request, bodyFormat));
+				}
+
+				// how would this work???
+				var verifier = new Verifier(expectedProps, actualPropsList, url);
+				verifier.VerifyExpectations();
+				//***********************
+			}
+			else
+			{
+				var webRouteReader = new Reader();
+				var actualProps = webRouteReader.GetRequestProperties(routeData, httpContext.Request, bodyFormat);
+				var verifier = new Verifier(expectedProps, actualProps, url);
+				verifier.VerifyExpectations();
+			}
 		}
 
 		internal static void NoRoute(RouteCollection routes, string url)


### PR DESCRIPTION
**Please DO NOT merge. This is only an idea on how to fix the issue. It does NOT compile.**

I spent some time digging through the ASP.NET MVC codebase. I noticed that the [DefaultControllerFactory](https://github.com/ASP-NET-MVC/aspnetwebstack/blob/master/src/System.Web.Mvc/DefaultControllerFactory.cs) made calls to an extension method called `HasDirectRouteMatch()` and I thought that could be used to find the correct `RouteData`. Unfortunately `GetDirectRouteMatches()` still returns multiple `RouteData` instances, but perhaps you could iterate over each of those instances and call `VerifyExpectations()`? If one of them comes back without any errors, then that would be the correct route.

The `DirectRouteExtensions.cs` file is [a file I took](https://github.com/ASP-NET-MVC/aspnetwebstack/blob/master/src/System.Web.Mvc/Routing/DirectRouteExtensions.cs) from the ASP.NET MVC codebase, but with modifications.

I don't know if this is the correct approach, but I did verify that the `Verifier` class did work against the route `GET ~/VerbedAttr` but then failed (which was expected) against the route `POST ~/VerbedAttr`.
