### PR TITLE
adding overloads to allow passing headers

### DIFF
--- a/src/MvcRouteTester/ApiRoute/ApiRouteAssert.cs
+++ b/src/MvcRouteTester/ApiRoute/ApiRouteAssert.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Web.Http;
 using System.Web.Http.Dispatcher;
@@ -16,16 +17,16 @@ namespace MvcRouteTester.ApiRoute
 
 		internal static Type ControllerSelectorType;
 
-		internal static void HasRoute(HttpConfiguration config, string url, HttpMethod httpMethod)
+		internal static void HasRoute(HttpConfiguration config, string url, HttpMethod httpMethod, Dictionary<string, string> headers)
 		{
 			var absoluteUrl = UrlHelpers.MakeAbsolute(url);
-			ReadRequestProperties(config, absoluteUrl, httpMethod, string.Empty, BodyFormat.None);
+			ReadRequestProperties(config, absoluteUrl, httpMethod, headers, string.Empty, BodyFormat.None);
 		}
 
-		internal static void HasRoute(HttpConfiguration config, string url, HttpMethod httpMethod, string body, BodyFormat bodyFormat, RouteValues expectedProps)
+		internal static void HasRoute(HttpConfiguration config, string url, HttpMethod httpMethod, Dictionary<string, string> headers, string body, BodyFormat bodyFormat, RouteValues expectedProps)
 		{
 			var absoluteUrl = UrlHelpers.MakeAbsolute(url);
-			var actualProps = ReadRequestProperties(config, absoluteUrl, httpMethod, body, bodyFormat);
+			var actualProps = ReadRequestProperties(config, absoluteUrl, httpMethod, headers, body, bodyFormat);
 
 			var verifier = new Verifier(expectedProps, actualProps, url);
 			verifier.VerifyExpectations();
@@ -138,13 +139,22 @@ namespace MvcRouteTester.ApiRoute
 			}
 		}
 
-		private static RouteValues ReadRequestProperties(HttpConfiguration config, string url, HttpMethod httpMethod, string body, BodyFormat bodyFormat)
+		private static RouteValues ReadRequestProperties(HttpConfiguration config, string url, HttpMethod httpMethod, Dictionary<string, string> headers, string body, BodyFormat bodyFormat)
 		{
 			var request = new HttpRequestMessage(httpMethod, url);
+
+		    if (headers != null)
+		    {
+                foreach (var header in headers)
+                {
+                    request.Headers.Add(header.Key, header.Value);
+                }
+		    }
 			request.Content = new StringContent(body);
 
 			var routeGenerator = new Generator(config, request);
 			return routeGenerator.ReadRequestProperties(url, httpMethod, bodyFormat);
 		}
-	}
+
+    }
 }

--- a/src/MvcRouteTester/Fluent/UrlAndHttpRoutes.cs
+++ b/src/MvcRouteTester/Fluent/UrlAndHttpRoutes.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Net.Http;
 using System.Web.Http;
@@ -37,43 +38,66 @@ namespace MvcRouteTester.Fluent
 			return this;
 		}
 
-		public UrlAndHttpRoutes To<TController>(Expression<Func<TController, object>> action) where TController : ApiController
+	    public UrlAndHttpRoutes To<TController>(Expression<Func<TController, object>> action) where TController : ApiController
+	    {
+	        return To<TController>((Dictionary<string,string>)null, action);
+	    }
+        
+		public UrlAndHttpRoutes To<TController>(Dictionary<string, string> headers, Expression<Func<TController, object>> action) where TController : ApiController
 		{
 			var expressionReader = new ExpressionReader();
 			var expectedProps = expressionReader.Read(action);
 
-			ApiRouteAssert.HasRoute(Configuration, Url, HttpMethod, requestBody, bodyFormat, expectedProps);
+			ApiRouteAssert.HasRoute(Configuration, Url, HttpMethod, headers, requestBody, bodyFormat, expectedProps);
 
 			return this;
 		}
 
+	    public UrlAndHttpRoutes To<TController>(HttpMethod httpMethod, Expression<Func<TController, object>> action)
+	        where TController : ApiController
+	    {
+	        return To<TController>(httpMethod, null, action);
+	    }
 
-		public UrlAndHttpRoutes To<TController>(HttpMethod httpMethod, Expression<Func<TController, object>> action) where TController : ApiController
+		public UrlAndHttpRoutes To<TController>(HttpMethod httpMethod, Dictionary<string, string> headers, Expression<Func<TController, object>> action) where TController : ApiController
 		{
 			var expressionReader = new ExpressionReader();
 			var expectedProps = expressionReader.Read(action);
 
-			ApiRouteAssert.HasRoute(Configuration, Url, httpMethod, requestBody, bodyFormat, expectedProps);
+			ApiRouteAssert.HasRoute(Configuration, Url, httpMethod, headers, requestBody, bodyFormat, expectedProps);
 
 			return this;
 		}
 
-		public UrlAndHttpRoutes To<TController>(HttpMethod httpMethod, Expression<Action<TController>> action) where TController : ApiController
+	    public UrlAndHttpRoutes To<TController>(HttpMethod httpMethod, Expression<Action<TController>> action)
+	        where TController : ApiController
+	    {
+	        return To<TController>(httpMethod, null, action);
+
+	    }
+
+		public UrlAndHttpRoutes To<TController>(HttpMethod httpMethod, Dictionary<string, string> headers, Expression<Action<TController>> action) where TController : ApiController
 		{
 			var expressionReader = new ExpressionReader();
 			var expectedProps = expressionReader.Read(action);
 
-			ApiRouteAssert.HasRoute(Configuration, Url, httpMethod, requestBody, bodyFormat, expectedProps);
+			ApiRouteAssert.HasRoute(Configuration, Url, httpMethod, headers, requestBody, bodyFormat, expectedProps);
 
 			return this;
 		}
 
-		public UrlAndHttpRoutes To<TController>(Expression<Action<TController>> action) where TController : ApiController
+	    public UrlAndHttpRoutes To<TController>(Expression<Action<TController>> action)
+	        where TController : ApiController
+	    {
+	        return To<TController>((Dictionary<string,string>)null, action);
+
+	    }
+		public UrlAndHttpRoutes To<TController>(Dictionary<string, string> headers, Expression<Action<TController>> action) where TController : ApiController
 		{
 			var expressionReader = new ExpressionReader();
 			var expectedProps = expressionReader.Read(action);
 
-			ApiRouteAssert.HasRoute(Configuration, Url, HttpMethod, requestBody, bodyFormat, expectedProps);
+			ApiRouteAssert.HasRoute(Configuration, Url, HttpMethod, headers, requestBody, bodyFormat, expectedProps);
 
 			return this;
 		}

--- a/src/MvcRouteTester/RouteAssert.cs
+++ b/src/MvcRouteTester/RouteAssert.cs
@@ -165,36 +165,64 @@ namespace MvcRouteTester
 		/// <summary>
 		/// Asserts that the API route exists, has the specified Http method
 		/// </summary>
-		public static void HasApiRoute(HttpConfiguration config, string url, HttpMethod httpMethod)
+	    public static void HasApiRoute(HttpConfiguration config, string url, HttpMethod httpMethod)
+	    {
+	        HasApiRoute(config, url, httpMethod, null);
+	    }
+
+		/// <summary>
+		/// Asserts that the API route exists, has the specified Http method
+		/// </summary>
+		public static void HasApiRoute(HttpConfiguration config, string url, HttpMethod httpMethod, Dictionary<string, string> headers)
 		{
-			ApiRouteAssert.HasRoute(config, url, httpMethod);
+			ApiRouteAssert.HasRoute(config, url, httpMethod, headers);
 		}
 
 		/// <summary>
 		/// Asserts that the API route exists, has the specified Http method and meets the expectations
 		/// </summary>
-		public static void HasApiRoute(HttpConfiguration config, string url, HttpMethod httpMethod, object expectations)
+	    public static void HasApiRoute(HttpConfiguration config, string url, HttpMethod httpMethod, object expectations)
+	    {
+            HasApiRoute(config, url, httpMethod, (Dictionary<string, string>)null, expectations);
+	    }
+
+		/// <summary>
+		/// Asserts that the API route exists, has the specified Http method and meets the expectations
+		/// </summary>
+		public static void HasApiRoute(HttpConfiguration config, string url, HttpMethod httpMethod, Dictionary<string, string> headers,  object expectations)
 		{
 			var propertyReader = new PropertyReader();
 			var expectedProps = propertyReader.RouteValues(expectations);
 
-			ApiRouteAssert.HasRoute(config, url, httpMethod, string.Empty, BodyFormat.None, expectedProps);
+			ApiRouteAssert.HasRoute(config, url, httpMethod, headers, string.Empty, BodyFormat.None, expectedProps);
 		}
 
-		public static void HasApiRoute(HttpConfiguration config, string url, HttpMethod httpMethod, string body, object expectations)
+	    public static void HasApiRoute(HttpConfiguration config, string url, HttpMethod httpMethod,
+	        string body, object expectations)
+	    {
+            HasApiRoute(config, url, httpMethod, null, body, expectations);
+	    }
+
+		public static void HasApiRoute(HttpConfiguration config, string url, HttpMethod httpMethod, Dictionary<string, string> headers, string body, object expectations)
 		{
 			var propertyReader = new PropertyReader();
 			var expectedProps = propertyReader.RouteValues(expectations);
 
-			ApiRouteAssert.HasRoute(config, url, httpMethod, body, BodyFormat.FormUrl, expectedProps);
+			ApiRouteAssert.HasRoute(config, url, httpMethod, headers, body, BodyFormat.FormUrl, expectedProps);
 		}
 
-		public static void HasApiRoute(HttpConfiguration config, string url, HttpMethod httpMethod, string body, BodyFormat bodyFormat, object expectations)
+	    public static void HasApiRoute(HttpConfiguration config, string url, HttpMethod httpMethod,
+	        string body, BodyFormat bodyFormat, object expectations)
+	    {
+            HasApiRoute(config, url, httpMethod, null, body, bodyFormat, expectations);
+	    }
+
+		public static void HasApiRoute(HttpConfiguration config, string url, HttpMethod httpMethod, Dictionary<string, string> headers, string body, BodyFormat bodyFormat, object expectations)
 		{
 			var propertyReader = new PropertyReader();
 			var expectedProps = propertyReader.RouteValues(expectations);
 
-			ApiRouteAssert.HasRoute(config, url, httpMethod, body, bodyFormat, expectedProps);
+			ApiRouteAssert.HasRoute(config, url, httpMethod, headers, body, bodyFormat, expectedProps);
 		}
 
 		public static void HasApiRoute(HttpConfiguration config, string url, HttpMethod httpMethod, string controller, string action)
@@ -208,22 +236,22 @@ namespace MvcRouteTester
 			HasApiRoute(config, url, httpMethod, expectedProps);
 		}
 
-		public static void HasApiRoute(HttpConfiguration config, string url, HttpMethod httpMethod, IDictionary<string, string> expectedProps)
+		public static void HasApiRoute(HttpConfiguration config, string url, HttpMethod httpMethod, Dictionary<string, string> headers, IDictionary<string, string> expectedProps)
 		{
 			var expectedRouteValues = new RouteValues(expectedProps);
-			ApiRouteAssert.HasRoute(config, url, httpMethod, string.Empty, BodyFormat.None, expectedRouteValues);
+			ApiRouteAssert.HasRoute(config, url, httpMethod, headers, string.Empty, BodyFormat.None, expectedRouteValues);
 		}
 
-		public static void HasApiRoute(HttpConfiguration config, string url, HttpMethod httpMethod, string body, IDictionary<string, string> expectedProps)
+		public static void HasApiRoute(HttpConfiguration config, string url, HttpMethod httpMethod, Dictionary<string, string> headers, string body, IDictionary<string, string> expectedProps)
 		{
 			var expectedRouteValues = new RouteValues(expectedProps);
-			ApiRouteAssert.HasRoute(config, url, httpMethod, body, BodyFormat.FormUrl, expectedRouteValues);
+			ApiRouteAssert.HasRoute(config, url, httpMethod, headers, body, BodyFormat.FormUrl, expectedRouteValues);
 		}
 
-		public static void HasApiRoute(HttpConfiguration config, string url, HttpMethod httpMethod, string body, BodyFormat bodyFormat,  IDictionary<string, string> expectedProps)
+		public static void HasApiRoute(HttpConfiguration config, string url, HttpMethod httpMethod, Dictionary<string, string> headers, string body, BodyFormat bodyFormat,  IDictionary<string, string> expectedProps)
 		{
 			var expectedRouteValues = new RouteValues(expectedProps);
-			ApiRouteAssert.HasRoute(config, url, httpMethod, body, bodyFormat, expectedRouteValues);
+			ApiRouteAssert.HasRoute(config, url, httpMethod, headers, body, bodyFormat, expectedRouteValues);
 		}
 
 		/// <summary>


### PR DESCRIPTION
Allow passing headers to allow testing when using custom route constraint that checks request headers.
