### PR TITLE
Adding check for Enum in IsSimpleType

### DIFF
--- a/src/MvcRouteTester/Common/PropertyReader.cs
+++ b/src/MvcRouteTester/Common/PropertyReader.cs
@@ -39,7 +39,7 @@ namespace MvcRouteTester.Common
 				return true;
 			}
 
-			return type.IsPrimitive || SpecialSimpleTypes.Contains(type);
+			return type.IsPrimitive || SpecialSimpleTypes.Contains(type) || type.IsEnum;
 		}
 
 		public RouteValues RouteValues(object dataObject)


### PR DESCRIPTION
Without this check `ExpressionReader.ReadParameters` assumes it's a complex type, and tries to read the public properties of the Enum type. Since there aren't any public properties on an Enum, the call to `values.AddRange` in line 176 of the previously mentioned method won't add anything and the Enum parameter value will be lost. This change should fix that.
