### PR TITLE
Custom constraint resolver

### DIFF
--- a/src/MvcRouteTester.AttributeRouting.Test/Controllers/InlineConstraintController.cs
+++ b/src/MvcRouteTester.AttributeRouting.Test/Controllers/InlineConstraintController.cs
@@ -1,0 +1,27 @@
+﻿using System.Web;
+using System.Web.Mvc;
+using System.Web.Routing;
+
+namespace MvcRouteTester.AttributeRouting.Test.Controllers
+{
+    public class InlineConstraintController : Controller
+    {
+        [Route("inlineconstraint/{param:verb}")]
+		public ActionResult Index(string param)
+		{
+			return new EmptyResult();
+		}
+    }
+
+    public class CustomConstraint : IRouteConstraint
+    {
+        public bool Match(HttpContextBase httpContext, Route route, string parameterName, RouteValueDictionary values,
+            RouteDirection routeDirection)
+        {
+            object paramValue;
+            values.TryGetValue(parameterName, out paramValue);
+            
+            return paramValue != null && paramValue.ToString().EndsWith("ing");
+        }
+    }
+}

--- a/src/MvcRouteTester.AttributeRouting.Test/MvcRouteTester.AttributeRouting.Test.csproj
+++ b/src/MvcRouteTester.AttributeRouting.Test/MvcRouteTester.AttributeRouting.Test.csproj
@@ -96,12 +96,14 @@
     <Compile Include="ApiControllers\WithOptionalParamAttrController.cs" />
     <Compile Include="Controllers\GetPostAttrController.cs" />
     <Compile Include="Controllers\HomeAttrController.cs" />
+    <Compile Include="Controllers\InlineConstraintController.cs" />
     <Compile Include="Controllers\VerbedAttrController.cs" />
     <Compile Include="Controllers\WithAreaController.cs" />
     <Compile Include="FakeAssertEngine.cs" />
     <Compile Include="NunitAssertEngine.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="WebRoute\HomeAttrControllerFailTests.cs" />
+    <Compile Include="WebRoute\InlineConstraintControllerTests.cs" />
     <Compile Include="WebRoute\RouteMethodTests.cs" />
     <Compile Include="WebRoute\HomeAttrControllerTests.cs" />
     <Compile Include="WebRoute\VerbedAttrControllerTests.cs" />

--- a/src/MvcRouteTester.AttributeRouting.Test/WebRoute/HomeAttrControllerFailTests.cs
+++ b/src/MvcRouteTester.AttributeRouting.Test/WebRoute/HomeAttrControllerFailTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Web.Routing;
+﻿using System.Web.Mvc.Routing;
+using System.Web.Routing;
 
 using MvcRouteTester.AttributeRouting.Test.Controllers;
 
@@ -18,8 +19,11 @@ namespace MvcRouteTester.AttributeRouting.Test.WebRoute
 			assertEngine = new FakeAssertEngine();
 			RouteAssert.UseAssertEngine(assertEngine);
 
+            var defaultConstraintResolver = new DefaultInlineConstraintResolver();
+            defaultConstraintResolver.ConstraintMap.Add("verb", typeof(CustomConstraint));
+
 			routes = new RouteCollection();
-			routes.MapAttributeRoutesInAssembly(typeof(HomeAttrController));
+			routes.MapAttributeRoutesInAssembly(typeof(HomeAttrController), defaultConstraintResolver);
 		}
 
 		[Test]

--- a/src/MvcRouteTester.AttributeRouting.Test/WebRoute/HomeAttrControllerTests.cs
+++ b/src/MvcRouteTester.AttributeRouting.Test/WebRoute/HomeAttrControllerTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Web.Routing;
+﻿using System.Web.Mvc.Routing;
+using System.Web.Routing;
 
 using MvcRouteTester.AttributeRouting.Test.Controllers;
 
@@ -16,8 +17,11 @@ namespace MvcRouteTester.AttributeRouting.Test.WebRoute
 		{
 			RouteAssert.UseAssertEngine(new NunitAssertEngine());
 
+            var defaultConstraintResolver = new DefaultInlineConstraintResolver();
+            defaultConstraintResolver.ConstraintMap.Add("verb", typeof(CustomConstraint));
+
 			routes = new RouteCollection();
-			routes.MapAttributeRoutesInAssembly(typeof(HomeAttrController));
+			routes.MapAttributeRoutesInAssembly(typeof(HomeAttrController), defaultConstraintResolver);
 		}
 
 		[Test]

--- a/src/MvcRouteTester.AttributeRouting.Test/WebRoute/InlineConstraintControllerTests.cs
+++ b/src/MvcRouteTester.AttributeRouting.Test/WebRoute/InlineConstraintControllerTests.cs
@@ -1,0 +1,58 @@
+﻿using System.Web.Mvc.Routing;
+using System.Web.Routing;
+
+using MvcRouteTester.AttributeRouting.Test.Controllers;
+
+using NUnit.Framework;
+
+namespace MvcRouteTester.AttributeRouting.Test.WebRoute
+{
+    [TestFixture]
+    public class InlineConstraintControllerTests
+    {
+        private RouteCollection routes;
+
+        [SetUp]
+        public void Setup()
+        {
+            RouteAssert.UseAssertEngine(new NunitAssertEngine());
+
+            var defaultConstraintResolver = new DefaultInlineConstraintResolver();
+            defaultConstraintResolver.ConstraintMap.Add("verb", typeof(CustomConstraint));
+
+            routes = new RouteCollection();
+            routes.MapAttributeRoutesInAssembly(typeof(InlineConstraintController), defaultConstraintResolver);
+        }
+
+        [Test]
+        public void HasRoutesInTable()
+        {
+            Assert.That(routes.Count, Is.GreaterThan(0));
+        }
+
+        [Test]
+        public void HasHomeRoute()
+        {
+            var expectedRoute = new { controller = "InlineConstraint", action = "Index" };
+            RouteAssert.HasRoute(routes, "/inlineconstraint/drawing", expectedRoute);
+        }
+
+        [Test]
+        public void DoesNotHaveInvalidRoute()
+        {
+            RouteAssert.NoRoute(routes, "/inlineconstraint/draw");
+        }
+
+        [Test]
+        public void HasFluentRoute()
+        {
+            routes.ShouldMap("/inlineconstraint/drawing").To<InlineConstraintController>(x => x.Index("drawing"));
+        }
+
+        [Test]
+        public void HasFluentNoRoute()
+        {
+            routes.ShouldMap("/inlineconstraint/draw").ToNoRoute();
+        }
+    }
+}

--- a/src/MvcRouteTester.AttributeRouting.Test/WebRoute/RouteMethodTests.cs
+++ b/src/MvcRouteTester.AttributeRouting.Test/WebRoute/RouteMethodTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Web.Routing;
+﻿using System.Web.Mvc.Routing;
+using System.Web.Routing;
 
 using MvcRouteTester.AttributeRouting.Test.Controllers;
 
@@ -14,8 +15,11 @@ namespace MvcRouteTester.AttributeRouting.Test.WebRoute
 		[SetUp]
 		public void Setup()
 		{
+            var defaultConstraintResolver = new DefaultInlineConstraintResolver();
+            defaultConstraintResolver.ConstraintMap.Add("verb", typeof(CustomConstraint));
+
 			routes = new RouteCollection();
-			routes.MapAttributeRoutesInAssembly(typeof(HomeAttrController));
+			routes.MapAttributeRoutesInAssembly(typeof(HomeAttrController), defaultConstraintResolver);
 		}
 
 		[Test]

--- a/src/MvcRouteTester.AttributeRouting.Test/WebRoute/VerbedAttrControllerTests.cs
+++ b/src/MvcRouteTester.AttributeRouting.Test/WebRoute/VerbedAttrControllerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http;
+using System.Web.Mvc.Routing;
 using System.Web.Routing;
 
 using MvcRouteTester.AttributeRouting.Test.Controllers;
@@ -17,8 +18,11 @@ namespace MvcRouteTester.AttributeRouting.Test.WebRoute
 		{
 			RouteAssert.UseAssertEngine(new NunitAssertEngine());
 
+            var defaultConstraintResolver = new DefaultInlineConstraintResolver();
+            defaultConstraintResolver.ConstraintMap.Add("verb", typeof(CustomConstraint));
+
 			routes = new RouteCollection();
-			routes.MapAttributeRoutesInAssembly(typeof(HomeAttrController));
+			routes.MapAttributeRoutesInAssembly(typeof(HomeAttrController), defaultConstraintResolver);
 		}
 
 		[Test]

--- a/src/MvcRouteTester.AttributeRouting.Test/WebRoute/WithAreaTests.cs
+++ b/src/MvcRouteTester.AttributeRouting.Test/WebRoute/WithAreaTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Web.Routing;
+﻿using System.Web.Mvc.Routing;
+using System.Web.Routing;
 
 using MvcRouteTester.AttributeRouting.Test.Controllers;
 
@@ -13,8 +14,11 @@ namespace MvcRouteTester.AttributeRouting.Test.WebRoute
 		[SetUp]
 		public void Setup()
 		{
+            var defaultConstraintResolver = new DefaultInlineConstraintResolver();
+            defaultConstraintResolver.ConstraintMap.Add("verb", typeof(CustomConstraint));
+
 			routes = new RouteCollection();
-			routes.MapAttributeRoutesInAssembly(typeof(WithAreaController).Assembly);
+			routes.MapAttributeRoutesInAssembly(typeof(WithAreaController).Assembly, defaultConstraintResolver);
 		}
 
 		[Test]

--- a/src/MvcRouteTester/Common/MvcAssemblyReflector.cs
+++ b/src/MvcRouteTester/Common/MvcAssemblyReflector.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Reflection;
 using System.Web.Mvc;
+using System.Web.Mvc.Routing;
 using System.Web.Routing;
 
 namespace MvcRouteTester.Common
@@ -23,10 +24,10 @@ namespace MvcRouteTester.Common
 			LoadMvcAssembly();
 		}
 
-		public void MapAttributeRoutes(RouteCollection routes, IEnumerable<Type> controllers)
+		public void MapAttributeRoutes(RouteCollection routes, IEnumerable<Type> controllers, IInlineConstraintResolver constraintResolver)
 		{
 			var mapMvcAttributeRoutesMethod = GetMapRoutesMethod();
-			mapMvcAttributeRoutesMethod.Invoke(null, new object[] { routes, controllers });
+			mapMvcAttributeRoutesMethod.Invoke(null, new object[] { routes, controllers, constraintResolver });
 		}
 		
 		public object GetDirectRouteCandidatesFor(ControllerContext controllerContext)
@@ -99,7 +100,7 @@ namespace MvcRouteTester.Common
 			var resultMethod = attributeRoutingMapperType.GetMethod("MapAttributeRoutes",
 				BindingFlags.Public | BindingFlags.Static,
 				null,
-				new[] { typeof(RouteCollection), typeof(IEnumerable<Type>) },
+                new[] { typeof(RouteCollection), typeof(IEnumerable<Type>), typeof(IInlineConstraintResolver) },
 				null);
 
 			CheckMethod(resultMethod, "System.Web.Mvc.Routing.AttributeRoutingMapper", "MapAttributeRoutes");

--- a/src/MvcRouteTester/WebRouteTestMapper.cs
+++ b/src/MvcRouteTester/WebRouteTestMapper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Web.Mvc;
+using System.Web.Mvc.Routing;
 using System.Web.Routing;
 
 using MvcRouteTester.Common;
@@ -11,17 +12,27 @@ namespace MvcRouteTester
 {
 	public static class WebRouteTestMapper
 	{
-		public static void MapAttributeRoutesInAssembly(this RouteCollection routes, Type type)
+	    public static void MapAttributeRoutesInAssembly(this RouteCollection routes, Type type)
+	    {
+	        MapAttributeRoutesInAssembly(routes, type, new DefaultInlineConstraintResolver());
+	    }
+
+	    public static void MapAttributeRoutesInAssembly(this RouteCollection routes, Type type, IInlineConstraintResolver constraintResolver)
 		{
-			MapAttributeRoutesInAssembly(routes, type.Assembly);
+			MapAttributeRoutesInAssembly(routes, type.Assembly, constraintResolver);
 		}
 
-		public static void MapAttributeRoutesInAssembly(this RouteCollection routes, Assembly assembly)
+	    public static void MapAttributeRoutesInAssembly(this RouteCollection routes, Assembly assembly)
+	    {
+	        MapAttributeRoutesInAssembly(routes, assembly, new DefaultInlineConstraintResolver());
+	    }
+
+	    public static void MapAttributeRoutesInAssembly(this RouteCollection routes, Assembly assembly, IInlineConstraintResolver constraintResolver)
 		{
 			var controllers = (assembly.GetExportedTypes()
 				.Where(IsControllerType)).ToList();
 
-			MapAttributeRoutesInControllers(routes, controllers);
+			MapAttributeRoutesInControllers(routes, controllers, constraintResolver);
 		}
 
 		private static bool IsControllerType(Type t)
@@ -31,10 +42,10 @@ namespace MvcRouteTester
 				&& typeof(IController).IsAssignableFrom(t);
 		}
 
-		public static void MapAttributeRoutesInControllers(this RouteCollection routes, IEnumerable<Type> controllers)
+		public static void MapAttributeRoutesInControllers(this RouteCollection routes, IEnumerable<Type> controllers, IInlineConstraintResolver constraintResolver)
 		{
 			var mvcAssemblyReflector = new MvcAssemblyReflector();
-			mvcAssemblyReflector.MapAttributeRoutes(routes, controllers);
+			mvcAssemblyReflector.MapAttributeRoutes(routes, controllers, constraintResolver);
 		}
 	}
 }


### PR DESCRIPTION
We needed to be able to use custom constraint resolver in our controller. Since registration of attribute routing happens to all controllers on the assembly, it was either we have drop testing routes with MvcRouteTests or to extend it.  So we extended to support testing of custom constraints through attribute routing.

Also updated tests. Let me know if you need anything else from us to merge this to master.