### PR TITLE
Support custom simple model types which have a string converter (i.e. TypeConverter).

### DIFF
--- a/src/MvcRouteTester.Test/ApiControllers/WithSimpleObjectController.cs
+++ b/src/MvcRouteTester.Test/ApiControllers/WithSimpleObjectController.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.ComponentModel;
+using System.Globalization;
+using System.Net.Http;
+using System.Web.Http;
+
+namespace MvcRouteTester.Test.ApiControllers
+{
+	[TypeConverter(typeof(SimpleInputModelConverter))]
+	public class SimpleInputModel
+	{
+		public uint X { get; set; }
+		public uint Y { get; set; }
+
+		public override string ToString()
+		{
+			return X + "-" + Y;
+		}
+
+		public static SimpleInputModel Parse(string value)
+		{
+			var elements = value.Split('-');
+
+			return new SimpleInputModel
+			{
+				X = UInt32.Parse(elements[0]),
+				Y = UInt32.Parse(elements[1])
+			};
+		}
+	}
+
+	class SimpleInputModelConverter : TypeConverter
+	{
+		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+		{
+			return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+		}
+
+		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+		{
+			var str = value as string;
+			if (str != null)
+			{
+				return new InputModel { Name = str };
+			}
+
+			return base.ConvertFrom(context, culture, value);
+		}
+	}
+
+	public class WithSimpleObjectController : ApiController
+	{
+		public HttpResponseMessage Get(SimpleInputModel data)
+		{
+			return new HttpResponseMessage();
+		}
+	}
+}

--- a/src/MvcRouteTester.Test/ApiRoute/SimpleModelBindingTests.cs
+++ b/src/MvcRouteTester.Test/ApiRoute/SimpleModelBindingTests.cs
@@ -1,0 +1,60 @@
+﻿using System.Net.Http;
+using System.Web.Http;
+
+using MvcRouteTester.Test.ApiControllers;
+using MvcRouteTester.Test.Assertions;
+
+using NUnit.Framework;
+
+namespace MvcRouteTester.Test.ApiRoute
+{
+	[TestFixture]
+	public class SimpleModelBindingTests
+	{
+		private HttpConfiguration config;
+
+		[SetUp]
+		public void MakeRouteTable()
+		{
+			RouteAssert.UseAssertEngine(new NunitAssertEngine());
+
+			config = new HttpConfiguration();
+
+			config.Routes.MapHttpRoute(
+				name: "DefaultApi",
+				routeTemplate: "api/{controller}/{data}");
+		}
+
+		[Test]
+		public void TestHasApiRouteToCorrectController()
+		{
+			var expectations = new
+			{
+				controller = "WithSimpleObject",
+				action = "Get"
+			};
+			RouteAssert.HasApiRoute(config, "/api/withsimpleobject/1-2", HttpMethod.Get, expectations);
+		}
+
+		[Test]
+		public void TestHasApiRouteParams()
+		{
+			var expectations = new
+				{
+					controller = "WithSimpleObject",
+					action = "Get",
+					data = "1-2"
+				};
+
+			RouteAssert.HasApiRoute(config, "/api/withsimpleobject/1-2", HttpMethod.Get, expectations);
+		}
+
+		[Test]
+		public void TestFluentMap()
+		{
+			config.ShouldMap("/api/withsimpleobject/1-2").To<WithSimpleObjectController>(HttpMethod.Get,
+				c => c.Get(new SimpleInputModel { X = 1, Y = 2 }));
+		}
+
+	}
+}

--- a/src/MvcRouteTester.Test/Common/PropertyReaderIsSimpleTypeTests.cs
+++ b/src/MvcRouteTester.Test/Common/PropertyReaderIsSimpleTypeTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using MvcRouteTester.Common;
+using MvcRouteTester.Test.ApiControllers;
 using NUnit.Framework;
 
 namespace MvcRouteTester.Test.Common
@@ -81,6 +82,12 @@ namespace MvcRouteTester.Test.Common
 		public void NullableIntIsSimpleType()
 		{
 			Assert.That(reader.IsSimpleType(typeof(int?)), Is.True);
+		}
+
+		[Test]
+		public void SimpleInputModelIsSimpleType()
+		{
+			Assert.That(reader.IsSimpleType(typeof(SimpleInputModel)), Is.True);
 		}
 	}
 }

--- a/src/MvcRouteTester.Test/MvcRouteTester.Test.csproj
+++ b/src/MvcRouteTester.Test/MvcRouteTester.Test.csproj
@@ -99,6 +99,7 @@
     <Compile Include="ApiControllers\CustomerController.cs" />
     <Compile Include="ApiControllers\WithDateTimeController.cs" />
     <Compile Include="ApiControllers\WithNullableController.cs" />
+    <Compile Include="ApiControllers\WithSimpleObjectController.cs" />
     <Compile Include="ApiControllers\WithObjectController.cs" />
     <Compile Include="ApiControllers\WithOptionalParamController.cs" />
     <Compile Include="ApiRoute\AsyncActionControllerTests.cs" />
@@ -111,6 +112,7 @@
     <Compile Include="ApiRoute\FluentExtensionsTests.cs" />
     <Compile Include="ApiRoute\FromFormUrlBodyTests.cs" />
     <Compile Include="ApiRoute\JsonBodyReaderTests.cs" />
+    <Compile Include="ApiRoute\SimpleModelBindingTests.cs" />
     <Compile Include="ApiRoute\ModelBindingTests.cs" />
     <Compile Include="ApiRoute\NullableParamTests.cs" />
     <Compile Include="ApiRoute\OptionalParamTests.cs" />

--- a/src/MvcRouteTester/Common/PropertyReader.cs
+++ b/src/MvcRouteTester/Common/PropertyReader.cs
@@ -7,14 +7,6 @@ namespace MvcRouteTester.Common
 {
 	public class PropertyReader
 	{
-		private static readonly List<Type> SpecialSimpleTypes = new List<Type>
-			{
-				typeof(string),
-				typeof(decimal),
-				typeof(DateTime),
-				typeof(Guid)
-			};
-
 		private static readonly IgnoreAttributes IgnoreAttributes = new IgnoreAttributes();
 
 		public static void AddIgnoreAttributes(IEnumerable<Type> types)
@@ -34,12 +26,7 @@ namespace MvcRouteTester.Common
 
 		public bool IsSimpleType(Type type)
 		{
-			if (type.Name == "Nullable`1")
-			{
-				return true;
-			}
-
-			return type.IsPrimitive || SpecialSimpleTypes.Contains(type) || type.IsEnum;
+			return TypeHelper.CanConvertFromString(type);
 		}
 
 		public RouteValues RouteValues(object dataObject)

--- a/src/MvcRouteTester/Common/TypeHelper.cs
+++ b/src/MvcRouteTester/Common/TypeHelper.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace MvcRouteTester.Common
+{
+	public static class TypeHelper
+	{
+		public static bool CanConvertFromString(Type destinationType)
+		{
+			return IsBasicType(UnwrapNullableType(destinationType)) ||
+				   HasStringConverter(destinationType);
+		}
+
+		private static Type UnwrapNullableType(Type destinationType)
+		{
+			return Nullable.GetUnderlyingType(destinationType) ?? destinationType;
+		}
+
+		public static bool IsBasicType(Type type)
+		{
+			return type.IsPrimitive ||
+				   type.IsEnum ||
+				   type == typeof(decimal) ||
+				   type == typeof(string) ||
+				   type == typeof(DateTime) ||
+				   type == typeof(Guid) ||
+				   type == typeof(DateTimeOffset) ||
+				   type == typeof(TimeSpan) ||
+				   type == typeof(Uri);
+		}
+
+		public static bool HasStringConverter(Type type)
+		{
+			return TypeDescriptor.GetConverter(type).CanConvertFrom(typeof(string));
+		}
+	}
+}

--- a/src/MvcRouteTester/MvcRouteTester.csproj
+++ b/src/MvcRouteTester/MvcRouteTester.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Common\DirectRouteHelper.cs" />
     <Compile Include="Common\IgnoreAttributes.cs" />
     <Compile Include="Common\MvcAssemblyReflector.cs" />
+    <Compile Include="Common\TypeHelper.cs" />
     <Compile Include="Common\RouteValue.cs" />
     <Compile Include="Common\RouteValueExtensions.cs" />
     <Compile Include="Common\RouteValueOrigin.cs" />


### PR DESCRIPTION
Hello Anthony,

I've been using your MvcRouteTester for a while and I think it's great! The current project I'm working has multiple controllers that need to be able to receive a model type from a single string. Obviously this be done by using the property on the model type. But it would decrease code readability and the quality of the auto-generated web api documentation. Therefore I took the time to add support for custom model types to be classified as simple if they have a string converter. I also improved the simple type classification in general. Please see commit comments.

Oh and in addition, I added tests to demonstrate that it works!