### PR TITLE
Added support for testing async JsonResult actions

### DIFF
--- a/src/MvcRouteTester.Test/Controllers/AsyncActionController.cs
+++ b/src/MvcRouteTester.Test/Controllers/AsyncActionController.cs
@@ -11,5 +11,11 @@ namespace MvcRouteTester.Test.Controllers
 			Func<ActionResult> responseFunc = () => new EmptyResult();
 			return Task<ActionResult>.Factory.StartNew(responseFunc);
 		}
+
+        public Task<JsonResult> JsonAsync(int id)
+        {
+            Func<JsonResult> responseFunc = () => new JsonResult();
+            return Task<JsonResult>.Factory.StartNew(responseFunc);
+        }
 	}
 }

--- a/src/MvcRouteTester.Test/WebRoute/AsyncActionControllerTests.cs
+++ b/src/MvcRouteTester.Test/WebRoute/AsyncActionControllerTests.cs
@@ -42,7 +42,7 @@ namespace MvcRouteTester.Test.WebRoute
 		[Test]
 		public void ShouldWorkWithFluent()
 		{
-			routes.ShouldMap("/AsyncAction/IndexAsync/42").To<AsyncActionController>(c => c.IndexAsync(42));
+			routes.ShouldMap("/AsyncAction/JsonAsync/42").To<AsyncActionController>(c => c.JsonAsync(42));
 		}
 	}
 }

--- a/src/MvcRouteTester.Test/WebRoute/AsyncActionControllerTests.cs
+++ b/src/MvcRouteTester.Test/WebRoute/AsyncActionControllerTests.cs
@@ -40,9 +40,15 @@ namespace MvcRouteTester.Test.WebRoute
 		}
 
 		[Test]
-		public void ShouldWorkWithFluent()
+		public void ShouldWorkWithFluentActionResult()
 		{
-			routes.ShouldMap("/AsyncAction/JsonAsync/42").To<AsyncActionController>(c => c.JsonAsync(42));
+			routes.ShouldMap("/AsyncAction/IndexAsync/42").To<AsyncActionController>(c => c.IndexAsync(42));
 		}
+
+        [Test]
+        public void ShouldWorkWithFluentJsonResult()
+        {
+            routes.ShouldMap("/AsyncAction/JsonAsync/42").To<AsyncActionController>(c => c.JsonAsync(42));
+        }
 	}
 }

--- a/src/MvcRouteTester/Fluent/ExpressionReader.cs
+++ b/src/MvcRouteTester/Fluent/ExpressionReader.cs
@@ -20,6 +20,11 @@ namespace MvcRouteTester.Fluent
 			return Read(typeof(TController), UnwrapAction(action));
 		}
 
+        public RouteValues Read<TController>(Expression<Func<TController, Task<JsonResult>>> action)
+        {
+            return Read(typeof(TController), UnwrapAction(action));
+        }
+
 		public RouteValues Read<TController>(Expression<Func<TController, ActionResult>> action)
 		{
 			return Read(typeof(TController), UnwrapAction(action));

--- a/src/MvcRouteTester/Fluent/UrlAndRoutes.cs
+++ b/src/MvcRouteTester/Fluent/UrlAndRoutes.cs
@@ -67,6 +67,11 @@ namespace MvcRouteTester.Fluent
 			To(HttpMethod, action);
 		}
 
+        public void To<TController>(Expression<Func<TController, Task<JsonResult>>> action) where TController : Controller
+        {
+            To(HttpMethod, action);
+        }
+
 		public void To<TController>(HttpMethod httpMethod, Expression<Func<TController, Task<ActionResult>>> action) where TController : Controller
 		{
 			var expressionReader = new ExpressionReader();
@@ -74,6 +79,14 @@ namespace MvcRouteTester.Fluent
 
 			WebRouteAssert.HasRoute(Routes, httpMethod, Url, requestBody, bodyFormat, expectedProps);
 		}
+
+        public void To<TController>(HttpMethod httpMethod, Expression<Func<TController, Task<JsonResult>>> action) where TController : Controller
+        {
+            var expressionReader = new ExpressionReader();
+            var expectedProps = expressionReader.Read(action);
+
+            WebRouteAssert.HasRoute(Routes, httpMethod, Url, requestBody, bodyFormat, expectedProps);
+        }
 
 		public void ToNoRoute()
 		{


### PR DESCRIPTION
Noticed while using this package that it wasn't supporting async actions that return JsonResult objects via the fluent syntax. The following would generate a compiler error:

    routes.ShouldMap("/Async/JsonAsync/123")
                .To<AsyncController>(HttpMethod.Post, x => x.JsonAsync(123));

Where the `JsonAsync` method returns a `Task<JsonResult>`. Added some method overrides to introduce support for this and a new unit test to verify its behaviour.