### PR TITLE
fix for async actions that accept CancellationToken as parameter

### DIFF
--- a/src/MvcRouteTester.Test/ApiControllers/AsyncActionController.cs
+++ b/src/MvcRouteTester.Test/ApiControllers/AsyncActionController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Web.Http;
 
@@ -12,5 +13,11 @@ namespace MvcRouteTester.Test.ApiControllers
 			Func<HttpResponseMessage> responseFunc = () => new HttpResponseMessage();
 			return Task<HttpResponseMessage>.Factory.StartNew(responseFunc);
 		}
-	}
+
+        public Task<HttpResponseMessage> PutWithCancellationAsync(int id, CancellationToken cancellationToken)
+        {
+            Func<HttpResponseMessage> responseFunc = () => new HttpResponseMessage();
+            return Task<HttpResponseMessage>.Factory.StartNew(responseFunc, cancellationToken);
+        }
+    }
 }

--- a/src/MvcRouteTester.Test/ApiRoute/AsyncActionControllerTests.cs
+++ b/src/MvcRouteTester.Test/ApiRoute/AsyncActionControllerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http;
+using System.Threading;
 using System.Web.Http;
 
 using MvcRouteTester.Test.ApiControllers;
@@ -33,18 +34,39 @@ namespace MvcRouteTester.Test.ApiRoute
 			RouteAssert.HasApiRoute(config, "/api/AsyncAction", HttpMethod.Get, expectedRoute);
 		}
 
-		[Test]
+        [Test]
+        public void RecognisesSimpleRouteAndCancellationToken()
+        {
+            var expectedRoute = new { controller = "AsyncAction", action = "PutWithCancellationAsync" };
+            RouteAssert.HasApiRoute(config, "/api/AsyncAction", HttpMethod.Put, expectedRoute);
+        }
+
+        [Test]
 		public void RecognisesRouteWithParams()
 		{
 			var expectedRoute = new { controller = "AsyncAction", action = "GetAsync" };
 			RouteAssert.HasApiRoute(config, "/api/AsyncAction/123", HttpMethod.Get, expectedRoute);
 		}
 
-		[Test]
+        [Test]
+        public void RecognisesRouteWithParamsAndCancellationToken()
+        {
+            var expectedRoute = new { controller = "AsyncAction", action = "PutWithCancellationAsync" };
+            RouteAssert.HasApiRoute(config, "/api/AsyncAction/123", HttpMethod.Put, expectedRoute);
+        }
+
+        [Test]
 		public void RecognisesFluentRoute()
 		{
 			config.ShouldMap("/api/AsyncAction/123")
 				.To<AsyncActionController>(HttpMethod.Get, x => x.GetAsync(123));
 		}
-	}
+
+        [Test]
+        public void RecognisesFluentRouteWithCancelllationToken()
+        {
+            config.ShouldMap("/api/AsyncAction/40")
+                .To<AsyncActionController>(HttpMethod.Put, x => x.PutWithCancellationAsync(40, CancellationToken.None));
+        }
+    }
 }

--- a/src/MvcRouteTester.Test/Controllers/AsyncActionController.cs
+++ b/src/MvcRouteTester.Test/Controllers/AsyncActionController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Web.Mvc;
 
@@ -6,16 +7,28 @@ namespace MvcRouteTester.Test.Controllers
 {
 	public class AsyncActionController : Controller
 	{
-		public Task<ActionResult> IndexAsync(int id)
+        public Task<ActionResult> IndexAsync(int id)
 		{
 			Func<ActionResult> responseFunc = () => new EmptyResult();
 			return Task<ActionResult>.Factory.StartNew(responseFunc);
 		}
+
+        public Task<ActionResult> IndexWithCancellationAsync(int id, CancellationToken cancellationToken)
+        {
+            Func<ActionResult> responseFunc = () => new EmptyResult();
+            return Task<ActionResult>.Factory.StartNew(responseFunc, cancellationToken);
+        }
 
         public Task<JsonResult> JsonAsync(int id)
         {
             Func<JsonResult> responseFunc = () => new JsonResult();
             return Task<JsonResult>.Factory.StartNew(responseFunc);
         }
-	}
+
+        public Task<JsonResult> JsonWithCancellationAsync(int id, CancellationToken cancellationToken)
+        {
+            Func<JsonResult> responseFunc = () => new JsonResult();
+            return Task<JsonResult>.Factory.StartNew(responseFunc, cancellationToken);
+        }
+    }
 }

--- a/src/MvcRouteTester.Test/WebRoute/AsyncActionControllerTests.cs
+++ b/src/MvcRouteTester.Test/WebRoute/AsyncActionControllerTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Web.Mvc;
+﻿using System.Threading;
+using System.Web.Mvc;
 using System.Web.Routing;
 
 using MvcRouteTester.Test.Assertions;
@@ -46,9 +47,21 @@ namespace MvcRouteTester.Test.WebRoute
 		}
 
         [Test]
+        public void ShouldWorkWithFluentActionResultAndCancellationToken()
+        {
+            routes.ShouldMap("/AsyncAction/IndexWithCancellationAsync/42").To<AsyncActionController>(c => c.IndexWithCancellationAsync(42, CancellationToken.None));
+        }
+
+        [Test]
         public void ShouldWorkWithFluentJsonResult()
         {
             routes.ShouldMap("/AsyncAction/JsonAsync/42").To<AsyncActionController>(c => c.JsonAsync(42));
         }
-	}
+
+        [Test]
+        public void ShouldWorkWithFluentJsonResultAndCancellationToken()
+        {
+            routes.ShouldMap("/AsyncAction/JsonWithCancellationAsync/42").To<AsyncActionController>(c => c.JsonWithCancellationAsync(42, CancellationToken.None));
+        }
+    }
 }

--- a/src/MvcRouteTester/Fluent/ExpressionReader.cs
+++ b/src/MvcRouteTester/Fluent/ExpressionReader.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Web.Mvc;
 using MvcRouteTester.Common;
@@ -164,7 +165,13 @@ namespace MvcRouteTester.Fluent
 			for (int i = 0; i < parameters.Length; i++)
 			{
 				var param = parameters[i];
-				var expectedValue = GetExpectedValue(arguments[i]);
+
+                if (param.ParameterType == typeof(CancellationToken))
+                {
+                    continue;
+                }
+
+                var expectedValue = GetExpectedValue(arguments[i]);
 				var isFromBody = attributeRecogniser.IsFromBody(param);
 				var routeValueOrigin = isFromBody ? RouteValueOrigin.Body : RouteValueOrigin.Unknown;
 				if (expectedValue != null || !isFromBody)


### PR DESCRIPTION
You can have CancellationToken as one of the parameters in ASP.NET MVC/WebAPI action. Then this parameter will be automatically provided by the framework.

Current version of MvcRouteTester tries to find a match to this parameter among provided values which is wrong. My pull request fixes this issue.